### PR TITLE
Add parameter to skip node creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ The plugin adds a global `fileLoader` DSL variable, which provides methods for l
 ### Available methods
 
 The `fileLoader` variable provides the following methods:
-* `fromGit(String libPath, String repository, String branch, String credentialsId, String labelExpression)` - loading of a single Groovy file from the specified Git repository
-* `withGit(String repository, String branch, String credentialsId, String labelExpression)` - wrapper closure for multiple files loading from a same Git repo
-* `fromSVN(String libPath, String repository, String credentialsId, String labelExpression)` - loading of a single Groovy file from the specified SVN repository
-* `withSVN(String repository, String credentialsId, String labelExpression)` - wrapper closure for multiple files loading from a same SVN repo
+* `fromGit(String libPath, String repository, String branch, String credentialsId, String labelExpression, boolean skipNode)` - loading of a single Groovy file from the specified Git repository
+* `withGit(String repository, String branch, String credentialsId, String labelExpression, boolean skipNode)` - wrapper closure for multiple files loading from a same Git repo
+* `fromSVN(String libPath, String repository, String credentialsId, String labelExpression, boolean skipNode)` - loading of a single Groovy file from the specified SVN repository
+* `withSVN(String repository, String credentialsId, String labelExpression, boolean skipNode)` - wrapper closure for multiple files loading from a same SVN repo
 
 * `load(String libPath)` - loading of an object from a Groovy file specified by the relative path. Also can be used within `withGit()` closure to load multiple objects at once
 
@@ -30,6 +30,7 @@ Parameters:
 * `branch` - Optional: Branch to be used (it's also possible to specify labels). Default value: `master`
 * `credentialsId` - Optional: Credentials to be used for the Git repo checkout. Default value: `null` (unauthorized access)
 * `labelExpression` - Optional: label expression, which specifies a node to be used for checkout. Default value: empty string (runs on any node)
+* `skipNode` - Optional: If true the creation of a new node is skipped. Default value: false (creates a new node)
 
 ### Groovy file format
 


### PR DESCRIPTION
We had the problem that one of our servers used to many nodes. The culprit was the remoteloader which used two nodes for every of our builds. So i hacked together a possibility to skip the node creation. Perhaps this is usefull for others.