### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <name>Jenkins Pipeline Remote Loader Plugin</name>
   <description>Allows loading Pipeline scripts from remote locations (enhanced version of the built-in load command)</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Remote+Loader+Plugin</url>
+  <url>https://github.com/jenkinsci/workflow-remote-loader-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A . Wiki was just a stub before it. A release will be needed to get the change applied.
