### PR TITLE
Remove github.com subversion tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/remoteloader/FileLoaderDSLTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/remoteloader/FileLoaderDSLTest.java
@@ -49,23 +49,6 @@ public class FileLoaderDSLTest {
     
     @Rule
     public JenkinsRule j = new JenkinsRule();
-    
-
-    @Test
-    public void loadSingleFileFromSVN() throws Exception {
-        assertSnippet("loadSingleFileFromSVN", false);
-    }
-    
-    @Test
-    public void loadSingleFileFromSVN_Sandbox() throws Exception {
-        assertSnippet("loadSingleFileFromSVN", true);
-    }
-    
-    @Test
-    public void loadMultipleFilesFromSVN() throws Exception {
-        assertSnippet("loadMultipleFilesFromSVN", false);
-    }
-
 
     @Test
     public void loadSingleFileFromGit() throws Exception {


### PR DESCRIPTION
## Remove github.com subversion tests

https://github.com/github/roadmap/issues/834 announces the end of life of Subversion support from github.com.

Remove the tests that relied on github.com subversion support.

### Testing done

Confirmed that tests pass after the change and that they failed before the change.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
